### PR TITLE
Task 6. IDistributedSemaphore

### DIFF
--- a/Libs/CoreLib/CoreLib.sln
+++ b/Libs/CoreLib/CoreLib.sln
@@ -4,6 +4,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreLib", "CoreLib\CoreLib.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IdentityConnectionLib", "IdentityConnectionLib\IdentityConnectionLib.csproj", "{2D38C801-1F1C-48F3-AAE3-EF2E0D021936}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DistributedLock", "DistributedLock\DistributedLock.csproj", "{9CE230E8-6193-4C88-8B00-73D038211B7F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +20,9 @@ Global
 		{2D38C801-1F1C-48F3-AAE3-EF2E0D021936}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2D38C801-1F1C-48F3-AAE3-EF2E0D021936}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2D38C801-1F1C-48F3-AAE3-EF2E0D021936}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9CE230E8-6193-4C88-8B00-73D038211B7F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9CE230E8-6193-4C88-8B00-73D038211B7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9CE230E8-6193-4C88-8B00-73D038211B7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9CE230E8-6193-4C88-8B00-73D038211B7F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Libs/CoreLib/DistributedLock/DistributedLock.csproj
+++ b/Libs/CoreLib/DistributedLock/DistributedLock.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="ZooKeeper.Net" Version="3.4.6.2" />
+    </ItemGroup>
+
+</Project>

--- a/Libs/CoreLib/DistributedLock/DistributedLock.csproj
+++ b/Libs/CoreLib/DistributedLock/DistributedLock.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="ZooKeeper.Net" Version="3.4.6.2" />
+      <PackageReference Include="ZooKeeperNetEx" Version="3.4.12.4" />
     </ItemGroup>
 
 </Project>

--- a/Libs/CoreLib/DistributedLock/Interfaces/IDistributedSemaphore.cs
+++ b/Libs/CoreLib/DistributedLock/Interfaces/IDistributedSemaphore.cs
@@ -1,0 +1,79 @@
+﻿namespace DistributedLock.Interfaces;
+
+/// <summary>
+/// A synchronization primitive which restricts access to a resource or critical section of code to a fixed number of concurrent threads/processes.
+/// Compare to <see cref="Semaphore"/>.
+/// </summary>
+public interface IDistributedSemaphore
+{
+    /// <summary>
+    /// A name that uniquely identifies the semaphore
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// The maximum number of "tickets" available for the semaphore (ie the number of processes which can acquire
+    /// the semaphore concurrently).
+    /// </summary>
+    int MaxCount { get; }
+
+    /// <summary>
+    /// Attempts to acquire a semaphore ticket synchronously. Usage: 
+    /// <code>
+    ///     using (var handle = mySemaphore.TryAcquire(...))
+    ///     {
+    ///         if (handle != null) { /* we have the ticket! */ }
+    ///     }
+    ///     // dispose releases the ticket if we took it
+    /// </code>
+    /// </summary>
+    /// <param name="timeout">How long to wait before giving up on the acquisition attempt. Defaults to 0</param>
+    /// <param name="cancellationToken">Specifies a token by which the wait can be canceled</param>
+    /// <returns>An <see cref="IDistributedSynchronizationHandle"/> which can be used to release the ticket or null on failure</returns>
+    IDistributedSynchronizationHandle? TryAcquire(TimeSpan timeout = default, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Acquires a semaphore ticket synchronously, failing with <see cref="TimeoutException"/> if the attempt times out. Usage: 
+    /// <code>
+    ///     using (mySemaphore.Acquire(...))
+    ///     {
+    ///         /* we have the ticket! */
+    ///     }
+    ///     // dispose releases the ticket
+    /// </code>
+    /// </summary>
+    /// <param name="timeout">How long to wait before giving up on the acquisition attempt. Defaults to <see cref="Timeout.InfiniteTimeSpan"/></param>
+    /// <param name="cancellationToken">Specifies a token by which the wait can be canceled</param>
+    /// <returns>An <see cref="IDistributedSynchronizationHandle"/> which can be used to release the ticket</returns>
+    IDistributedSynchronizationHandle Acquire(TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Attempts to acquire a semaphore ticket asynchronously. Usage: 
+    /// <code>
+    ///     await using (var handle = await mySemaphore.TryAcquireAsync(...))
+    ///     {
+    ///         if (handle != null) { /* we have the ticket! */ }
+    ///     }
+    ///     // dispose releases the ticket if we took it
+    /// </code>
+    /// </summary>
+    /// <param name="timeout">How long to wait before giving up on the acquisition attempt. Defaults to 0</param>
+    /// <param name="cancellationToken">Specifies a token by which the wait can be canceled</param>
+    /// <returns>An <see cref="IDistributedSynchronizationHandle"/> which can be used to release the ticket or null on failure</returns>
+    ValueTask<IDistributedSynchronizationHandle?> TryAcquireAsync(TimeSpan timeout = default, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Acquires a semaphore ticket asynchronously, failing with <see cref="TimeoutException"/> if the attempt times out. Usage: 
+    /// <code>
+    ///     await using (await mySemaphore.AcquireAsync(...))
+    ///     {
+    ///         /* we have the ticket! */
+    ///     }
+    ///     // dispose releases the ticket
+    /// </code>
+    /// </summary>
+    /// <param name="timeout">How long to wait before giving up on the acquisition attempt. Defaults to <see cref="Timeout.InfiniteTimeSpan"/></param>
+    /// <param name="cancellationToken">Specifies a token by which the wait can be canceled</param>
+    /// <returns>An <see cref="IDistributedSynchronizationHandle"/> which can be used to release the ticket</returns>
+    ValueTask<IDistributedSynchronizationHandle> AcquireAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+}

--- a/Libs/CoreLib/DistributedLock/Interfaces/IDistributedSynchronizationHandle.cs
+++ b/Libs/CoreLib/DistributedLock/Interfaces/IDistributedSynchronizationHandle.cs
@@ -1,0 +1,25 @@
+﻿namespace DistributedLock.Interfaces;
+
+/// <summary>
+/// A handle to a distributed lock or other synchronization primitive. To unlock/release,
+/// simply dispose the handle.
+/// </summary>
+public interface IDistributedSynchronizationHandle
+    : IDisposable, IAsyncDisposable
+{
+    /// <summary>
+    /// Gets a <see cref="CancellationToken"/> instance which may be used to 
+    /// monitor whether the handle to the lock is lost before the handle is
+    /// disposed. 
+    /// 
+    /// For example, this could happen if the lock is backed by a 
+    /// database and the connection to the database is disrupted.
+    /// 
+    /// Not all lock types support this; those that don't will return <see cref="CancellationToken.None"/>
+    /// which can be detected by checking <see cref="CancellationToken.CanBeCanceled"/>.
+    /// 
+    /// For lock types that do support this, accessing this property may incur additional
+    /// costs, such as polling to detect connectivity loss.
+    /// </summary>
+    CancellationToken HandleLostToken { get; }
+}

--- a/Libs/CoreLib/DistributedLock/ZooKeeperDistributedSemaphore.cs
+++ b/Libs/CoreLib/DistributedLock/ZooKeeperDistributedSemaphore.cs
@@ -8,85 +8,22 @@ public class ZookeeperDistributedSemaphore : IDistributedSemaphore
     private readonly ZooKeeper _zookeeper;
     private readonly string _semaphorePath;
     private readonly int _maxPermits;
-    private readonly string _lockPath;
 
     public ZookeeperDistributedSemaphore(ZooKeeper zookeeper, string semaphorePath, int maxPermits)
     {
         _zookeeper = zookeeper;
         _semaphorePath = semaphorePath;
         _maxPermits = maxPermits;
-        _lockPath = $"{semaphorePath}/lock";
         
         if (!ExistsAsync(_semaphorePath).Result)
         {
             _zookeeper.createAsync(_semaphorePath, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT).Wait();
         }
     }
-
     public string Name => _semaphorePath;
 
     public int MaxCount => _maxPermits;
 
-    public IDistributedSynchronizationHandle? TryAcquire(TimeSpan timeout = default, CancellationToken cancellationToken = default)
-    {
-        var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        var task = TryAcquireInternal();
-        
-        if (task.Wait(timeout, cts.Token))
-            return task.Result;
-
-        cts.Cancel();
-        throw new TimeoutException("Failed to acquire semaphore within the specified timeout.");
-    }
-
-    public IDistributedSynchronizationHandle Acquire(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
-    {
-        timeout ??= Timeout.InfiniteTimeSpan;
-
-        var deadline = DateTime.UtcNow + timeout.Value;
-        while (deadline > DateTime.UtcNow || timeout == Timeout.InfiniteTimeSpan)
-        {
-            var time = timeout == Timeout.InfiniteTimeSpan ? Timeout.InfiniteTimeSpan : deadline - DateTime.UtcNow;
-            var handle = TryAcquire(time, cancellationToken);
-            if (handle != null)
-                return handle;
-
-            Thread.Sleep(100);
-        }
-
-        throw new TimeoutException("Failed to acquire semaphore within the specified timeout.");
-    }
-
-    public async ValueTask<IDistributedSynchronizationHandle?> TryAcquireAsync(TimeSpan timeout = default, CancellationToken cancellationToken = default)
-    {
-        var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        var task = TryAcquireInternal();
-        
-        if (await Task.WhenAny(task, Task.Delay(timeout, cts.Token)) == task)
-            return task.Result;
-
-        await cts.CancelAsync();
-        throw new TimeoutException("Failed to acquire semaphore within the specified timeout.");
-    }
-
-    public async ValueTask<IDistributedSynchronizationHandle> AcquireAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
-    {
-        timeout ??= Timeout.InfiniteTimeSpan;
-
-        var deadline = DateTime.UtcNow + timeout.Value;
-        while (deadline > DateTime.UtcNow || timeout == Timeout.InfiniteTimeSpan)
-        {
-            var time = timeout == Timeout.InfiniteTimeSpan ? Timeout.InfiniteTimeSpan : deadline - DateTime.UtcNow;
-            var handle = await TryAcquireAsync(time, cancellationToken);
-            if (handle != null)
-                return handle;
-
-            await Task.Delay(100, cancellationToken);
-        }
-
-        throw new TimeoutException("Failed to acquire semaphore within the specified timeout.");
-    }
-    
     private async Task<bool> ExistsAsync(string path)
     {
         try
@@ -100,23 +37,109 @@ public class ZookeeperDistributedSemaphore : IDistributedSemaphore
         }
     }
     
-    private async Task<IDistributedSynchronizationHandle?> TryAcquireInternal()
+    public IDistributedSynchronizationHandle? TryAcquire(TimeSpan timeout = default, CancellationToken cancellationToken = default)
+    {
+        var handle = TryAcquireInternal(timeout, cancellationToken).AsTask().GetAwaiter().GetResult();
+        return handle;
+    }
+
+    public IDistributedSynchronizationHandle Acquire(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+    {
+        var time = timeout ?? Timeout.InfiniteTimeSpan;
+        var handle = TryAcquireInternal(time, cancellationToken).AsTask().GetAwaiter().GetResult();
+        return handle ?? throw new TimeoutException("Failed to acquire semaphore within the specified timeout.");
+    }
+
+    public async ValueTask<IDistributedSynchronizationHandle?> TryAcquireAsync(TimeSpan timeout = default, CancellationToken cancellationToken = default)
+    {
+        var handle = await TryAcquireInternal(timeout, cancellationToken);
+        return handle;
+    }
+
+    public async ValueTask<IDistributedSynchronizationHandle> AcquireAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+    {
+        var time = timeout ?? Timeout.InfiniteTimeSpan;
+        var handle = await TryAcquireInternal(time, cancellationToken);
+        return handle ?? throw new TimeoutException("Failed to acquire semaphore within the specified timeout.");
+    }
+    
+    private async ValueTask<IDistributedSynchronizationHandle?> TryAcquireInternal(TimeSpan? timeout, CancellationToken cancellationToken = default)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        var guid =  Guid.NewGuid().ToString();
+        
+        do
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var handle = await TryGetHandle(guid);
+            if (handle != null)
+                return handle;
+
+            await Task.Delay(100, cancellationToken); // TODO константа 100, вынести в какой-то конфиг
+        } while (deadline > DateTime.UtcNow || timeout == Timeout.InfiniteTimeSpan);
+        
+        await CleanupTemporaryNode(guid); // не дождались блокировку, удаляем созданную ноду
+        return null;
+    }
+    
+    private async Task<IDistributedSynchronizationHandle?> TryGetHandle(string guid)
     {
         try
         {
-            var lockPath = await _zookeeper.createAsync(_lockPath, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
+            var baseLockPath = $"{_semaphorePath}/{guid}-lock-";
+            string lockPath;
+            
             var children = await _zookeeper.getChildrenAsync(_semaphorePath);
-            var count = children.Children.Count;
-
-            if (count <= _maxPermits)
-                return new ZookeeperDistributedSynchronizationHandle(_zookeeper, lockPath);
-
-            await _zookeeper.deleteAsync(lockPath);
-            return null;
+            var existingNode = children.Children.FirstOrDefault(child => child.StartsWith(guid));
+            if (existingNode != null)
+            {
+                lockPath = $"{_semaphorePath}/{existingNode}";
+            }
+            else
+            {
+                lockPath = await _zookeeper.createAsync(baseLockPath, new byte[0], 
+                    ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
+            }
+            
+            // Повторное получение дочерних узлов нужно для того, чтобы гарантировать, что во время ожидания 
+            // создания ноды если кто-то успеет создать ноду раньше нас, то мы об этом знали 
+            // TODO есть более оптимальный способ достичь этой гарантии?
+            var updatedChildren = await _zookeeper.getChildrenAsync(_semaphorePath); 
+            
+            var sortedChildren = SortChildren(updatedChildren.Children);
+            var nodePosition = sortedChildren.IndexOf(Path.GetFileName(lockPath));
+            return nodePosition < _maxPermits ? new ZookeeperDistributedSynchronizationHandle(_zookeeper, lockPath) : null;
         }
         catch (KeeperException.NodeExistsException)
         {
             return null;
+        }
+    }
+    
+    private List<string> SortChildren(IEnumerable<string> children)
+    {
+        return children.OrderBy(child => ExtractNumericSuffix(child)).ToList();
+    }
+    
+    private ulong ExtractNumericSuffix(string child)
+    {
+        var suffix = child.Split("-").Last();
+        return Convert.ToUInt64(suffix);
+    }
+    
+    private async Task CleanupTemporaryNode(string guid)
+    {
+        try
+        {
+            var children = await _zookeeper.getChildrenAsync(_semaphorePath);
+            var existingNode = children.Children.FirstOrDefault(child => child.StartsWith(guid));
+            if (existingNode != null)
+            {
+                await _zookeeper.deleteAsync($"{_semaphorePath}/{existingNode}");
+            }
+        }
+        catch (KeeperException.NoNodeException)
+        { // Игнорируем ошибку TODO добавить запись в лог, если будет эта ошибка?
         }
     }
 }

--- a/Libs/CoreLib/DistributedLock/ZooKeeperDistributedSemaphore.cs
+++ b/Libs/CoreLib/DistributedLock/ZooKeeperDistributedSemaphore.cs
@@ -1,0 +1,102 @@
+﻿using DistributedLock.Interfaces;
+using ZooKeeperNet;
+
+namespace DistributedLock;
+
+public class ZookeeperDistributedSemaphore : IDistributedSemaphore
+{
+    private readonly ZooKeeper _zookeeper;
+    private readonly string _semaphorePath;
+    private readonly int _maxPermits;
+    private readonly string _lockPath;
+
+    public ZookeeperDistributedSemaphore(ZooKeeper zookeeper, string semaphorePath, int maxPermits)
+    {
+        _zookeeper = zookeeper;
+        _semaphorePath = semaphorePath;
+        _maxPermits = maxPermits;
+        _lockPath = $"{semaphorePath}/lock";
+    }
+
+    public string Name => _semaphorePath;
+
+    public int MaxCount => _maxPermits;
+
+    public IDistributedSynchronizationHandle? TryAcquire(TimeSpan timeout = default, CancellationToken cancellationToken = default)
+    {
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var task = TryAcquireInternal();
+        
+        if (task.Wait(timeout, cts.Token))
+            return task.Result;
+
+        cts.Cancel();
+        throw new TimeoutException("Failed to acquire semaphore within the specified timeout.");
+    }
+
+    public IDistributedSynchronizationHandle Acquire(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+    {
+        timeout ??= Timeout.InfiniteTimeSpan;
+
+        var deadline = DateTime.UtcNow + timeout.Value;
+        while (DateTime.UtcNow < deadline)
+        {
+            var handle = TryAcquire(deadline - DateTime.UtcNow, cancellationToken);
+            if (handle != null)
+                return handle;
+
+            Thread.Sleep(100);
+        }
+
+        throw new TimeoutException("Failed to acquire semaphore within the specified timeout.");
+    }
+
+    public async ValueTask<IDistributedSynchronizationHandle?> TryAcquireAsync(TimeSpan timeout = default, CancellationToken cancellationToken = default)
+    {
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var task = TryAcquireInternal();
+        
+        if (await Task.WhenAny(task, Task.Delay(timeout, cts.Token)) == task)
+            return task.Result;
+
+        await cts.CancelAsync();
+        throw new TimeoutException("Failed to acquire semaphore within the specified timeout.");
+    }
+
+    public async ValueTask<IDistributedSynchronizationHandle> AcquireAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+    {
+        timeout ??= Timeout.InfiniteTimeSpan;
+
+        var deadline = DateTime.UtcNow + timeout.Value;
+        while (DateTime.UtcNow < deadline)
+        {
+            var handle = await TryAcquireAsync(deadline - DateTime.UtcNow, cancellationToken);
+            if (handle != null)
+                return handle;
+
+            await Task.Delay(100, cancellationToken);
+        }
+
+        throw new TimeoutException("Failed to acquire semaphore within the specified timeout.");
+    }
+    
+    private async Task<IDistributedSynchronizationHandle?> TryAcquireInternal()
+    {
+        try
+        {
+            var lockPath = await Task.Run(() => _zookeeper.Create(_lockPath, new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.EphemeralSequential));
+            var children = await Task.Run(() => _zookeeper.GetChildren(_semaphorePath, false));
+            var count = children.Count();
+
+            if (count <= _maxPermits)
+                return new ZookeeperDistributedSynchronizationHandle(_zookeeper, lockPath);
+
+            await Task.Run(() => _zookeeper.Delete(lockPath, -1));
+            return null;
+        }
+        catch (KeeperException.NodeExistsException)
+        {
+            return null;
+        }
+    }
+}

--- a/Libs/CoreLib/DistributedLock/ZooKeeperDistributedSemaphore.cs
+++ b/Libs/CoreLib/DistributedLock/ZooKeeperDistributedSemaphore.cs
@@ -1,5 +1,5 @@
 ﻿using DistributedLock.Interfaces;
-using ZooKeeperNet;
+using org.apache.zookeeper;
 
 namespace DistributedLock;
 
@@ -16,6 +16,11 @@ public class ZookeeperDistributedSemaphore : IDistributedSemaphore
         _semaphorePath = semaphorePath;
         _maxPermits = maxPermits;
         _lockPath = $"{semaphorePath}/lock";
+        
+        if (!ExistsAsync(_semaphorePath).Result)
+        {
+            _zookeeper.createAsync(_semaphorePath, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT).Wait();
+        }
     }
 
     public string Name => _semaphorePath;
@@ -39,9 +44,10 @@ public class ZookeeperDistributedSemaphore : IDistributedSemaphore
         timeout ??= Timeout.InfiniteTimeSpan;
 
         var deadline = DateTime.UtcNow + timeout.Value;
-        while (DateTime.UtcNow < deadline)
+        while (deadline > DateTime.UtcNow || timeout == Timeout.InfiniteTimeSpan)
         {
-            var handle = TryAcquire(deadline - DateTime.UtcNow, cancellationToken);
+            var time = timeout == Timeout.InfiniteTimeSpan ? Timeout.InfiniteTimeSpan : deadline - DateTime.UtcNow;
+            var handle = TryAcquire(time, cancellationToken);
             if (handle != null)
                 return handle;
 
@@ -68,9 +74,10 @@ public class ZookeeperDistributedSemaphore : IDistributedSemaphore
         timeout ??= Timeout.InfiniteTimeSpan;
 
         var deadline = DateTime.UtcNow + timeout.Value;
-        while (DateTime.UtcNow < deadline)
+        while (deadline > DateTime.UtcNow || timeout == Timeout.InfiniteTimeSpan)
         {
-            var handle = await TryAcquireAsync(deadline - DateTime.UtcNow, cancellationToken);
+            var time = timeout == Timeout.InfiniteTimeSpan ? Timeout.InfiniteTimeSpan : deadline - DateTime.UtcNow;
+            var handle = await TryAcquireAsync(time, cancellationToken);
             if (handle != null)
                 return handle;
 
@@ -80,18 +87,31 @@ public class ZookeeperDistributedSemaphore : IDistributedSemaphore
         throw new TimeoutException("Failed to acquire semaphore within the specified timeout.");
     }
     
+    private async Task<bool> ExistsAsync(string path)
+    {
+        try
+        {
+            var stat = await _zookeeper.existsAsync(path);
+            return stat != null;
+        }
+        catch (KeeperException.NoNodeException)
+        {
+            return false;
+        }
+    }
+    
     private async Task<IDistributedSynchronizationHandle?> TryAcquireInternal()
     {
         try
         {
-            var lockPath = await Task.Run(() => _zookeeper.Create(_lockPath, new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.EphemeralSequential));
-            var children = await Task.Run(() => _zookeeper.GetChildren(_semaphorePath, false));
-            var count = children.Count();
+            var lockPath = await _zookeeper.createAsync(_lockPath, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL);
+            var children = await _zookeeper.getChildrenAsync(_semaphorePath);
+            var count = children.Children.Count;
 
             if (count <= _maxPermits)
                 return new ZookeeperDistributedSynchronizationHandle(_zookeeper, lockPath);
 
-            await Task.Run(() => _zookeeper.Delete(lockPath, -1));
+            await _zookeeper.deleteAsync(lockPath);
             return null;
         }
         catch (KeeperException.NodeExistsException)

--- a/Libs/CoreLib/DistributedLock/ZookeeperDistributedSynchronizationHandle.cs
+++ b/Libs/CoreLib/DistributedLock/ZookeeperDistributedSynchronizationHandle.cs
@@ -1,5 +1,5 @@
 ﻿using DistributedLock.Interfaces;
-using ZooKeeperNet;
+using org.apache.zookeeper;
 
 namespace DistributedLock;
 
@@ -20,13 +20,13 @@ public class ZookeeperDistributedSynchronizationHandle : IDistributedSynchroniza
 
     public void Dispose()
     {
-        _zookeeper.Delete(_lockPath, -1);
+        _zookeeper.deleteAsync(_lockPath);
         _cancellationTokenSource.Cancel();
     }
 
     public async ValueTask DisposeAsync()
     {
-        await Task.Run(() => _zookeeper.Delete(_lockPath, -1));
+        await _zookeeper.deleteAsync(_lockPath);
         _cancellationTokenSource.Cancel();
     }
 }

--- a/Libs/CoreLib/DistributedLock/ZookeeperDistributedSynchronizationHandle.cs
+++ b/Libs/CoreLib/DistributedLock/ZookeeperDistributedSynchronizationHandle.cs
@@ -14,6 +14,9 @@ public class ZookeeperDistributedSynchronizationHandle : IDistributedSynchroniza
         _zookeeper = zookeeper;
         _lockPath = lockPath;
         _cancellationTokenSource = new CancellationTokenSource();
+        
+        var connectionWatcher = new ConnectionWatcher(this);
+        _zookeeper.existsAsync(_lockPath, connectionWatcher); // если сервис отвалится, будет получено уведомление об этом
     }
 
     public CancellationToken HandleLostToken => _cancellationTokenSource.Token;
@@ -27,6 +30,30 @@ public class ZookeeperDistributedSynchronizationHandle : IDistributedSynchroniza
     public async ValueTask DisposeAsync()
     {
         await _zookeeper.deleteAsync(_lockPath);
+        await _cancellationTokenSource.CancelAsync();
+    }
+
+    internal void NotifyConnectionLoss()
+    {
         _cancellationTokenSource.Cancel();
+    }
+
+    private sealed class ConnectionWatcher : Watcher
+    {
+        private readonly ZookeeperDistributedSynchronizationHandle _parent;
+
+        public ConnectionWatcher(ZookeeperDistributedSynchronizationHandle parent)
+        {
+            _parent = parent;
+        }
+
+        public override Task process(WatchedEvent @event)
+        {
+            if (@event.getState() == Event.KeeperState.Disconnected)
+            {
+                _parent.NotifyConnectionLoss();
+            }
+            return Task.CompletedTask;
+        }
     }
 }

--- a/Libs/CoreLib/DistributedLock/ZookeeperDistributedSynchronizationHandle.cs
+++ b/Libs/CoreLib/DistributedLock/ZookeeperDistributedSynchronizationHandle.cs
@@ -1,0 +1,32 @@
+﻿using DistributedLock.Interfaces;
+using ZooKeeperNet;
+
+namespace DistributedLock;
+
+public class ZookeeperDistributedSynchronizationHandle : IDistributedSynchronizationHandle
+{
+    private readonly ZooKeeper _zookeeper;
+    private readonly string _lockPath;
+    private readonly CancellationTokenSource _cancellationTokenSource;
+
+    public ZookeeperDistributedSynchronizationHandle(ZooKeeper zookeeper, string lockPath)
+    {
+        _zookeeper = zookeeper;
+        _lockPath = lockPath;
+        _cancellationTokenSource = new CancellationTokenSource();
+    }
+
+    public CancellationToken HandleLostToken => _cancellationTokenSource.Token;
+
+    public void Dispose()
+    {
+        _zookeeper.Delete(_lockPath, -1);
+        _cancellationTokenSource.Cancel();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await Task.Run(() => _zookeeper.Delete(_lockPath, -1));
+        _cancellationTokenSource.Cancel();
+    }
+}

--- a/PostService/Api/Api.csproj
+++ b/PostService/Api/Api.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\..\Libs\CoreLib\DistributedLock\DistributedLock.csproj" />
       <ProjectReference Include="..\Infrastructured\Infrastructured.csproj" />
       <ProjectReference Include="..\Services\Services.csproj" />
     </ItemGroup>

--- a/PostService/Api/Controllers/SemaphoreTestController.cs
+++ b/PostService/Api/Controllers/SemaphoreTestController.cs
@@ -14,7 +14,8 @@ public class SemaphoreController : ControllerBase
         _semaphore = semaphore;
     }
 
-    [HttpGet("test")]
+    // блокировка получена - блокировка снята
+    [HttpGet("one-acquire-one-lock")]
     public async Task<IActionResult> TestAsync()
     {
         try
@@ -33,5 +34,31 @@ public class SemaphoreController : ControllerBase
         {
             return StatusCode(503, ex.Message);
         }
+    }
+    
+    // спс ImAbobaBoy за тест
+    // 2 таски получат блокировку, 5 не получат
+    [HttpGet("many-acquire-one-lock")]
+    public async Task<IActionResult> Test2Async()
+    {
+        var tasks = Enumerable.Range(1, 7).Select(async i =>
+        {
+            await using (var handle = await _semaphore.TryAcquireAsync()) // TODO отлавливать случаи, когда отвалился сервис, который захватил блокировку
+            {
+                if (handle != null)
+                {
+                    Console.WriteLine($"Таска {i} получила блокировку");
+                    await Task.Delay(2000);
+                }
+                else
+                {
+                    Console.WriteLine($"Таска {i} не смогла получить блокировку");
+                }
+            }
+        });
+
+        await Task.WhenAll(tasks);
+
+        return Ok("Semaphore test completed successfully");
     }
 }

--- a/PostService/Api/Controllers/SemaphoreTestController.cs
+++ b/PostService/Api/Controllers/SemaphoreTestController.cs
@@ -1,0 +1,37 @@
+﻿using DistributedLock;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class SemaphoreController : ControllerBase
+{
+    private readonly ZookeeperDistributedSemaphore _semaphore;
+
+    public SemaphoreController(ZookeeperDistributedSemaphore semaphore)
+    {
+        _semaphore = semaphore;
+    }
+
+    [HttpGet("test")]
+    public async Task<IActionResult> TestAsync()
+    {
+        try
+        {
+            using (var handle = await _semaphore.AcquireAsync(TimeSpan.FromSeconds(5)))
+            {
+                if (handle == null)
+                    return StatusCode(503, "Resource unavailable");
+                
+                await Task.Delay(2000);
+                
+                return Ok("Semaphore test completed successfully");
+            }
+        }
+        catch (TimeoutException ex)
+        {
+            return StatusCode(503, ex.Message);
+        }
+    }
+}

--- a/PostService/Api/Program.cs
+++ b/PostService/Api/Program.cs
@@ -1,7 +1,9 @@
 using CoreLib.HttpLogic;
 using CoreLib.TraceIdLogic;
+using DistributedLock;
 using Infrastructured;
 using MassTransit;
+using org.apache.zookeeper;
 using Serilog;
 using Services;
 using Services.Consumers;
@@ -13,6 +15,11 @@ builder.Services.AddInfrastructuredServices();
 builder.Services.AddLogicServices();
 builder.Services.AddHttpRequestService();
 builder.Services.AddTraceId();
+
+// Создание ZooKeeper и ZookeeperDistributedSemaphore
+var zookeeper = new ZooKeeper("localhost:2181", 30000, null);
+builder.Services.AddSingleton(zookeeper);
+builder.Services.AddSingleton(new ZookeeperDistributedSemaphore(zookeeper, "/semaphore", 1));
 
 // Регистрация контроллеров
 builder.Services.AddEndpointsApiExplorer();

--- a/PostService/Api/Program.cs
+++ b/PostService/Api/Program.cs
@@ -17,9 +17,9 @@ builder.Services.AddHttpRequestService();
 builder.Services.AddTraceId();
 
 // Создание ZooKeeper и ZookeeperDistributedSemaphore
-var zookeeper = new ZooKeeper("localhost:2181", 30000, null);
+var zookeeper = new ZooKeeper("localhost:2181", 60000, null);
 builder.Services.AddSingleton(zookeeper);
-builder.Services.AddSingleton(new ZookeeperDistributedSemaphore(zookeeper, "/semaphore", 1));
+builder.Services.AddSingleton(new ZookeeperDistributedSemaphore(zookeeper, "/semaphore", 2)); // TODO константы, вынести в какой-то конфиг
 
 // Регистрация контроллеров
 builder.Services.AddEndpointsApiExplorer();

--- a/PostService/PostService.sln
+++ b/PostService/PostService.sln
@@ -14,6 +14,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreLib", "..\Libs\CoreLib\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IdentityConnectionLib", "..\Libs\CoreLib\IdentityConnectionLib\IdentityConnectionLib.csproj", "{A02FF056-E5BD-4C9E-8083-E58DE9F9F13B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DistributedLock", "..\Libs\CoreLib\DistributedLock\DistributedLock.csproj", "{C6F8E0D0-5B34-47EF-A67B-D2C1DC31ED49}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,9 +46,14 @@ Global
 		{A02FF056-E5BD-4C9E-8083-E58DE9F9F13B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A02FF056-E5BD-4C9E-8083-E58DE9F9F13B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A02FF056-E5BD-4C9E-8083-E58DE9F9F13B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C6F8E0D0-5B34-47EF-A67B-D2C1DC31ED49}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C6F8E0D0-5B34-47EF-A67B-D2C1DC31ED49}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C6F8E0D0-5B34-47EF-A67B-D2C1DC31ED49}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C6F8E0D0-5B34-47EF-A67B-D2C1DC31ED49}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{1FDE7E62-8EC2-45E4-8780-C1CBF6178A3C} = {786609FB-ABEB-4B2C-84F6-132BFCEA4CE7}
 		{A02FF056-E5BD-4C9E-8083-E58DE9F9F13B} = {786609FB-ABEB-4B2C-84F6-132BFCEA4CE7}
+		{C6F8E0D0-5B34-47EF-A67B-D2C1DC31ED49} = {786609FB-ABEB-4B2C-84F6-132BFCEA4CE7}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
- [x] Используя Redis или Zookeeper, реализовать примитив синхронизации Semaphore. Нужно: взять драйвер для интеграции с Redis или Zookeeper; на основе его API реализовать интерфейс IDistributedSemaphore.
    - За основу IDistributedSemaphore был взят [одноименный интерфейс](https://github.com/madelson/DistributedLock/blob/master/src/DistributedLock.Core/IDistributedSemaphore.cs) из библиотеки DistributedLock.
    - С помощью Zookeeper в классе `ZookeeperDistributedSemaphore` была реализована следующая логика:
        1.  Создаем эфемерный последовательный znode с префиксом "{_semaphorePath}/{guid}-lock-" (где _semaphorePath — имя ресурса, который блокируем (по дефолту "semaphore"), а guid — свежесгенерированный гуид).
        2. Получаем список детей _semaphorePath.
        3. Сортируем список детей по суффиксу.
        4. Если позиция созданной znode меньше максимально возможных блокировок, то отдаем блокировку, иначе null.
        5. Повторяем шаги 2-4 до тех пор, пока переданный timeout не истечет.
    - Дополнительно реализована логика отслеживания разрыва соединения с Zookeeper в классе `ZookeeperDistributedSynchronizationHandle`. 
